### PR TITLE
プリセット選択機能追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,15 @@
-# vue_gamepad_display
+# ボタン表示設定
 
-## Project setup
-```
-npm install
-```
+## キー項目
 
-### Compiles and hot-reloads for development
-```
-npm run serve
-```
+ - ブラウザ側のゲームパッドID
+ - Windows側のデバイスID
+ - プリセット名称
 
-### Compiles and minifies for production
-```
-npm run build
-```
+## タスク
 
-### Run your unit tests
-```
-npm run test:unit
-```
+ - プリセット名の入力
+ - プリセット名の選択
+ →ドロップダウン・テキストボックスが一つになっているものを使う？
 
-### Lints and fixes files
-```
-npm run lint
-```
-
-### Customize configuration
-See [Configuration Reference](https://cli.vuejs.org/config/).
+ 

--- a/src/button-pict-setting.ts
+++ b/src/button-pict-setting.ts
@@ -9,15 +9,18 @@ export class DropdownImage {
 }
 
 export class ButtonPictSetting {
+    public presetName = "";
     public gamepadId = "";
     public device_id = "";
+
 
     public settings: ButtonPictSettingData[] = [];
 
     public directionalPadUpFileName = "";
     public directionalPadDownFileName = "";
 
-    constructor(gamepadId: string, device_id: string) {
+    constructor(presetName: string, gamepadId: string, device_id: string) {
+        this.presetName = presetName;
         this.gamepadId = gamepadId;
         this.device_id = device_id;
 

--- a/src/components/KeyInputHistory.vue
+++ b/src/components/KeyInputHistory.vue
@@ -108,21 +108,11 @@ export default defineComponent({
           this.selectedGamepadId,
           this.selectedGamepadDevice
         );
-
-        console.log(
-          "Loaded buttonPictSetting. GamepadId : " +
-            this.buttonPictSetting.gamepadId +
-            " DeviceId : " +
-            this.buttonPictSetting.device_id
-        );
-        console.log(this.buttonPictSetting);
-
         this.connectToGetInputStream();
       }
     },
     onChangeDeviceSelection() {
       this.onChangeGamepadSelection();
-      console.log("onChangeDeviceSelection");
     },
     onChangePresetSelection() {
       this.onChangeGamepadSelection();
@@ -147,7 +137,7 @@ export default defineComponent({
       // フェッチ
       this.keyInputSource = new EventSource(Url);
       this.keyInputSource.addEventListener("error", (event: any) => {
-        console.log(event);
+        console.error(event);
         this.$toast.error(
           "入力情報の取得に失敗しました。サーバーが起動していること、URLが正しいことを確認してください。"
         );
@@ -288,8 +278,6 @@ export default defineComponent({
   mounted() {
     this.updateGamepads();
     // 最初の要素を選択
-    console.log(this.gamepads);
-
     window.addEventListener("gamepadconnected", this.updateGamepads);
     window.addEventListener("gamepaddisconnected", this.updateGamepads);
 
@@ -299,11 +287,6 @@ export default defineComponent({
         this.selectedPresetName,
         this.selectedGamepadId,
         this.selectedGamepadDevice
-      );
-
-      console.log(
-        "Loaded buttonPictSetting. GamepadId : " +
-          this.buttonPictSetting.gamepadId
       );
 
       this.setPresetNameList();

--- a/src/components/KeyInputHistory.vue
+++ b/src/components/KeyInputHistory.vue
@@ -30,7 +30,7 @@ export default defineComponent({
       previoutInputInfo: new GamepadKeyInputInfo(),
       inputInfo: new GamepadKeyInputInfo(),
 
-      buttonPictSetting: new ButtonPictSetting("", ""),
+      buttonPictSetting: new ButtonPictSetting("", "", ""),
       inputHistoryPropertyList: [] as any,
 
       dropdown_images: [] as DropdownImage[],

--- a/src/components/KeyInputHistory.vue
+++ b/src/components/KeyInputHistory.vue
@@ -282,7 +282,11 @@ export default defineComponent({
       console.log(this.buttonPictSetting);
     } else if (store.state.isUseTestInputStream) {
       // テスト用のボタン設定を取得
-      this.buttonPictSetting = store.getters.getButtonPictSetting("", "");
+      this.buttonPictSetting = store.getters.getButtonPictSetting(
+        "StreamingTest",
+        "",
+        ""
+      );
     }
 
     // assets/button_promptディレクトリ内のpngファイルをインポート

--- a/src/components/KeyInputHistory.vue
+++ b/src/components/KeyInputHistory.vue
@@ -131,8 +131,6 @@ export default defineComponent({
       this.keyInputSource.addEventListener(
         "message",
         (event: any) => {
-          console.log(event.data);
-
           // GetInputStreamResponseに変換
           const parsed = JSON.parse(event.data);
           const data = new GetInputStreamResponse(
@@ -167,7 +165,6 @@ export default defineComponent({
       // フェッチ
       this.keyInputSource = new EventSource(Url);
       this.keyInputSource.addEventListener("error", (event: any) => {
-        console.log(event);
         this.$toast.error(
           "入力情報の取得に失敗しました。サーバーが起動していること、URLが正しいことを確認してください。"
         );
@@ -175,8 +172,6 @@ export default defineComponent({
       this.keyInputSource.addEventListener(
         "message",
         (event: any) => {
-          console.log(event.data);
-
           // GetInputStreamResponseに変換
           const parsed = JSON.parse(event.data);
           const data = new GetInputStreamResponse(
@@ -192,9 +187,6 @@ export default defineComponent({
       console.log("Fetch url : " + Url);
     },
     addInputHistoryFromStream(data: GetInputStreamResponse) {
-      console.log("addInputHistoryFromStream called.");
-      console.log(data);
-
       // キー入力履歴を追加
 
       // 押下方向に応じて画像データを割り当て(テンキー方式のファイル順前提)
@@ -237,7 +229,6 @@ export default defineComponent({
         if (a.fileName > b.fileName) return 1;
         return 0;
       });
-      console.log(buttonFileDataList);
 
       const options = {
         directionFileData: directionFileData,

--- a/src/components/Settings/ButtonPromptDropdown.vue
+++ b/src/components/Settings/ButtonPromptDropdown.vue
@@ -59,8 +59,6 @@ export default defineComponent({
     },
     onChangeDropdownImage() {
       // ドロップダウンリストの選択が変更されたときの処理
-      console.log("onChangeDropdownImage");
-
       this.$emit(
         "changeDropdownImage",
         this.buttonIndex,
@@ -78,12 +76,6 @@ export default defineComponent({
       } else {
         this.selectedImageIndex = this.dropdown_images.findIndex(
           (image) => image.fileName === this.initialValue
-        );
-        console.log(
-          "<watch>Initial value : ",
-          this.initialValue,
-          " / selectedImageIndex : ",
-          this.selectedImageIndex
         );
       }
     },

--- a/src/components/Settings/DirectionPromptDropdown.vue
+++ b/src/components/Settings/DirectionPromptDropdown.vue
@@ -36,8 +36,6 @@ export default defineComponent({
   methods: {
     onChangeDropdownDirection() {
       // ドロップダウンリストの選択が変更されたときの処理
-      console.log("changeDropdownDirection");
-
       this.$emit(
         "changeDropdownDirection",
         this.buttonIndex,

--- a/src/components/Settings/InputSettings.vue
+++ b/src/components/Settings/InputSettings.vue
@@ -6,6 +6,7 @@ import ButtonPromptDropdown from "./ButtonPromptDropdown.vue";
 import DirectionPromptDropdown from "./DirectionPromptDropdown.vue";
 import { ButtonPictSetting } from "@/button-pict-setting";
 import store from "@/store";
+import { useToast } from "vue-toast-notification";
 
 export default defineComponent({
   name: "InputSettings",
@@ -57,6 +58,7 @@ export default defineComponent({
     },
     getCurrentSettingData(): ButtonPictSetting {
       // 画面に入力されているボタンの設定内容を取得
+      this.buttonPictSetting.presetName = this.presetName;
       this.buttonPictSetting.gamepadId = this.gamepadId;
       this.buttonPictSetting.device_id = this.deviceId;
 
@@ -86,31 +88,16 @@ export default defineComponent({
 
       return this.buttonPictSetting;
     },
-    onChangeButtonPrompt(
-      buttonIndex: number,
-      buttonPromptIndex: number,
-      selectedImageIndex: number,
-      selectedImageName: string
-    ) {
-      console.log(
-        `onChangeButtonPrompt: buttonIndex=${buttonIndex}, buttonPromptIndex=${buttonPromptIndex}, selectedImageIndex=${selectedImageIndex}, selectedImageName=${selectedImageName}`
-      );
-
+    onClickSaveButton() {
       // ボタンの設定内容を取得し、保存する
       const currentSettingData = this.getCurrentSettingData();
       store.commit("setButtonPictSetting", currentSettingData);
-    },
-    onChangeDirectionPrompt(
-      buttonIndex: number,
-      selectedDirectionIndex: number
-    ) {
-      console.log(
-        `onChangeDirectionPrompt: buttonIndex=${buttonIndex}, selectedDirectionIndex=${selectedDirectionIndex}`
-      );
 
-      // ボタンの設定内容を取得し、保存する
-      const currentSettingData = this.getCurrentSettingData();
-      store.commit("setButtonPictSetting", currentSettingData);
+      this.$toast.success(
+        "プリセット名「" +
+          this.presetName +
+          "」でボタン表示設定を保存しました。"
+      );
     },
     onGameLoop(
       debugInfo: DebugInfomation,
@@ -144,11 +131,27 @@ export default defineComponent({
     },
   },
   watch: {
+    presetName() {
+      // プリセット名選択が変更されたときの処理
+
+      // 保存済みのボタン設定を取得
+      this.buttonPictSetting = store.getters.getButtonPictSetting(
+        this.presetName,
+        this.gamepadId,
+        this.deviceId
+      );
+      console.log(
+        "<updateGamepad> Loaded buttonPictSetting. GamepadId : " +
+          this.buttonPictSetting.gamepadId
+      );
+      console.log(this.buttonPictSetting);
+    },
     gamepadId() {
       // ゲームパッドの選択が変更されたときの処理
 
       // 保存済みのボタン設定を取得
       this.buttonPictSetting = store.getters.getButtonPictSetting(
+        this.presetName,
         this.gamepadId,
         this.deviceId
       );
@@ -163,6 +166,7 @@ export default defineComponent({
 
       // 保存済みのボタン設定を取得
       this.buttonPictSetting = store.getters.getButtonPictSetting(
+        this.presetName,
         this.gamepadId,
         this.deviceId
       );
@@ -202,6 +206,8 @@ export default defineComponent({
 <template>
   <h1>ボタン表示設定</h1>
 
+  <input type="button" value="設定を保存" @click="onClickSaveButton" />
+
   <table>
     <thead>
       <th></th>
@@ -233,7 +239,6 @@ export default defineComponent({
                 index_button_prompt - 1
               ]
             "
-            @changeDropdownImage="onChangeButtonPrompt"
             ref="buttonPromptDropdown"
           ></ButtonPromptDropdown>
 
@@ -250,7 +255,6 @@ export default defineComponent({
             :initialValue="
               buttonPictSetting.settings[index_button - 1].directionalValue
             "
-            @changeDropdownDirection="onChangeDirectionPrompt"
             ref="directionPromptDropdown"
           />
 

--- a/src/components/Settings/InputSettings.vue
+++ b/src/components/Settings/InputSettings.vue
@@ -98,6 +98,8 @@ export default defineComponent({
           this.presetName +
           "」でボタン表示設定を保存しました。"
       );
+
+      this.$emit("onSaveButtonSetting");
     },
     onGameLoop(
       debugInfo: DebugInfomation,

--- a/src/components/Settings/InputSettings.vue
+++ b/src/components/Settings/InputSettings.vue
@@ -14,6 +14,10 @@ export default defineComponent({
     DirectionPromptDropdown,
   },
   props: {
+    presetName: {
+      type: String as PropType<string>,
+      required: true,
+    },
     gamepadId: {
       type: String as PropType<string>,
       required: true,
@@ -28,7 +32,11 @@ export default defineComponent({
       gamepads: [] as Gamepad[],
       selectedGamepadIndex: 0,
       inputInfo: new GamepadKeyInputInfo(),
-      buttonPictSetting: new ButtonPictSetting(this.gamepadId, this.deviceId),
+      buttonPictSetting: new ButtonPictSetting(
+        this.presetName,
+        this.gamepadId,
+        this.deviceId
+      ),
     };
   },
   methods: {

--- a/src/components/Settings/InputSettings.vue
+++ b/src/components/Settings/InputSettings.vue
@@ -89,8 +89,6 @@ export default defineComponent({
     },
     onClickDeleteButton() {
       // 現在のプリセットを削除する
-      console.log("onClickDeleteButton");
-
       if (
         window.confirm(
           "プリセット名「" +
@@ -156,11 +154,6 @@ export default defineComponent({
         this.gamepadId,
         this.deviceId
       );
-      console.log(
-        "<updateGamepad> Loaded buttonPictSetting. GamepadId : " +
-          this.buttonPictSetting.gamepadId
-      );
-      console.log(this.buttonPictSetting);
     },
     gamepadId() {
       // ゲームパッドの選択が変更されたときの処理
@@ -171,11 +164,6 @@ export default defineComponent({
         this.gamepadId,
         this.deviceId
       );
-      console.log(
-        "<updateGamepad> Loaded buttonPictSetting. GamepadId : " +
-          this.buttonPictSetting.gamepadId
-      );
-      console.log(this.buttonPictSetting);
     },
     deviceId() {
       // ゲームパッドの選択が変更されたときの処理
@@ -186,11 +174,6 @@ export default defineComponent({
         this.gamepadId,
         this.deviceId
       );
-      console.log(
-        "<updateGamepad> Loaded buttonPictSetting. GamepadId : " +
-          this.buttonPictSetting.gamepadId
-      );
-      console.log(this.buttonPictSetting);
     },
   },
   mounted() {
@@ -203,11 +186,6 @@ export default defineComponent({
       this.gamepadId,
       this.deviceId
     );
-    console.log(
-      "Loaded buttonPictSetting. GamepadId : " +
-        this.buttonPictSetting.gamepadId
-    );
-    console.log(this.buttonPictSetting);
 
     const gameLoop = GameLoop.instance;
     gameLoop.executeGameLoop(this.onGameLoop);

--- a/src/components/Settings/InputSettings.vue
+++ b/src/components/Settings/InputSettings.vue
@@ -10,6 +10,7 @@ import { useToast } from "vue-toast-notification";
 
 export default defineComponent({
   name: "InputSettings",
+  emits: ["onSaveButtonSetting", "onDeleteButtonSetting"],
   components: {
     ButtonPromptDropdown,
     DirectionPromptDropdown,
@@ -100,6 +101,34 @@ export default defineComponent({
       );
 
       this.$emit("onSaveButtonSetting");
+    },
+    onClickDeleteButton() {
+      // 現在のプリセットを削除する
+      console.log("onClickDeleteButton");
+
+      if (
+        window.confirm(
+          "プリセット名「" +
+            this.presetName +
+            "」のボタン表示設定を削除しますか？"
+        ) == false
+      ) {
+        return;
+      }
+
+      store.commit("deleteButtonPictSetting", {
+        presetName: this.presetName,
+        gamepadId: this.gamepadId,
+        device_id: this.deviceId,
+      });
+
+      this.$toast.warning(
+        "プリセット名「" +
+          this.presetName +
+          "」のボタン表示設定を削除しました。"
+      );
+
+      this.$emit("onDeleteButtonSetting");
     },
     onGameLoop(
       debugInfo: DebugInfomation,
@@ -209,6 +238,7 @@ export default defineComponent({
   <h1>ボタン表示設定</h1>
 
   <input type="button" value="設定を保存" @click="onClickSaveButton" />
+  <input type="button" value="設定を削除" @click="onClickDeleteButton" />
 
   <table>
     <thead>

--- a/src/components/Settings/InputSettings.vue
+++ b/src/components/Settings/InputSettings.vue
@@ -3,7 +3,6 @@ import { PropType, defineComponent } from "vue";
 import { DebugInfomation, GameLoop, GamepadKeyPressState } from "@/gameloop";
 import GamepadKeyInputInfo from "@/input-info";
 import ButtonPromptDropdown from "./ButtonPromptDropdown.vue";
-import DirectionPromptDropdown from "./DirectionPromptDropdown.vue";
 import { ButtonPictSetting } from "@/button-pict-setting";
 import store from "@/store";
 import { useToast } from "vue-toast-notification";
@@ -13,7 +12,6 @@ export default defineComponent({
   emits: ["onSaveButtonSetting", "onDeleteButtonSetting"],
   components: {
     ButtonPromptDropdown,
-    DirectionPromptDropdown,
   },
   props: {
     presetName: {
@@ -65,25 +63,12 @@ export default defineComponent({
 
       // ボタン設定
       var buttonDropdowns = this.$refs.buttonPromptDropdown as any;
-      var directionDropdowns = this.$refs.directionPromptDropdown as any;
 
       for (var i = 0; i < 16; i++) {
         // ボタン1-3の設定を取得
         for (var j = 0; j < 3; j++) {
           this.buttonPictSetting.settings[i].pictFileNames[j] =
             buttonDropdowns[i * 3 + j].selectedImageName;
-        }
-
-        // 方向キーの設定を取得
-        const directionSelectedValue = directionDropdowns[i].selectedValue;
-        console.log("directionSelectedValue=" + directionSelectedValue);
-        if (directionSelectedValue == -1) {
-          this.buttonPictSetting.settings[i].isDirectionalPad = false;
-          this.buttonPictSetting.settings[i].directionalValue = -1;
-        } else {
-          this.buttonPictSetting.settings[i].isDirectionalPad = true;
-          this.buttonPictSetting.settings[i].directionalValue =
-            directionSelectedValue;
         }
       }
 
@@ -246,7 +231,6 @@ export default defineComponent({
       <th>ボタン1</th>
       <th>ボタン2</th>
       <th>ボタン3</th>
-      <th>方向キー</th>
     </thead>
     <tbody>
       <tr v-for="index_button in 16" :key="index_button">
@@ -279,18 +263,6 @@ export default defineComponent({
               index_button_prompt - 1
             ]
           }}
-        </td>
-
-        <td>
-          <DirectionPromptDropdown
-            :buttonIndex="index_button"
-            :initialValue="
-              buttonPictSetting.settings[index_button - 1].directionalValue
-            "
-            ref="directionPromptDropdown"
-          />
-
-          {{ buttonPictSetting.settings[index_button - 1].directionalValue }}
         </td>
       </tr>
     </tbody>

--- a/src/components/SiteSettings.vue
+++ b/src/components/SiteSettings.vue
@@ -164,14 +164,21 @@ export default defineComponent({
           <input
             type="button"
             value="White"
-            class="white-bg-button"
+            style="background-color: #ffffff; color: black"
             @click="setBackGroundColor('#ffffff')"
           />
           <input
             type="button"
             value="Green"
-            class="green-bg-button"
+            style="background-color: #00ff00; color: black"
             @click="setBackGroundColor('#00ff00')"
+          />
+
+          <input
+            type="button"
+            value="Brown"
+            style="background-color: #552200; color: white"
+            @click="setBackGroundColor('#552200')"
           />
         </div>
       </div>
@@ -226,10 +233,10 @@ export default defineComponent({
 
       <hr />
 
-      <div v-if="selectedGamepadId === '' || selectedGamepadDevice === ''">
+      <!-- <div v-if="selectedGamepadId === '' || selectedGamepadDevice === ''">
         <p>【ゲームパッドを選択してください】</p>
-      </div>
-      <div v-else>
+      </div> -->
+      <div>
         <InputSettings
           :presetName="selectedPresetName"
           :gamepadId="selectedGamepadId"

--- a/src/components/SiteSettings.vue
+++ b/src/components/SiteSettings.vue
@@ -160,6 +160,18 @@ export default defineComponent({
       </legend>
 
       <div>
+        <p>
+          プリセット名を入力してください。同じパッドで複数のボタン表示を切り替えることができます。
+        </p>
+        <label for="listPresetName">プリセット名</label>
+        <input list="presetNameDataList" v-model="selectedPresetName" />
+        <datalist id="presetNameDataList">
+          <option value="Default"></option>
+          <option value="Custom"></option>
+        </datalist>
+
+        <hr />
+
         <p>ブラウザに接続されているゲームパッド</p>
         <select v-model="selectedGamepadId" @change="onChangeGamepadSelection">
           <option
@@ -188,13 +200,14 @@ export default defineComponent({
         </select>
       </div>
 
+      <hr />
+
       <div>
         <InputSettings
-          :selectedPresetName="selectedPresetName"
+          :presetName="selectedPresetName"
           :gamepadId="selectedGamepadId"
           :deviceId="selectedGamepadDevice"
         />
-        <!-- <KeyInputPreview :gamepadId="selectedGamepadId" /> -->
       </div>
     </fieldset>
   </div>

--- a/src/components/SiteSettings.vue
+++ b/src/components/SiteSettings.vue
@@ -21,6 +21,7 @@ export default defineComponent({
       isUseTestInputStream: store.state.isUseTestInputStream,
       gamepads: [] as Gamepad[],
       devices: [] as Device[],
+      selectedPresetName: "",
       selectedGamepadId: "",
       selectedGamepadDevice: "",
     };
@@ -189,6 +190,7 @@ export default defineComponent({
 
       <div>
         <InputSettings
+          :selectedPresetName="selectedPresetName"
           :gamepadId="selectedGamepadId"
           :deviceId="selectedGamepadDevice"
         />

--- a/src/components/SiteSettings.vue
+++ b/src/components/SiteSettings.vue
@@ -48,6 +48,12 @@ export default defineComponent({
       // ボタン設定の保存ボタン押下イベント
       this.setPresetNameList();
     },
+    onDeleteButtonSetting() {
+      // ボタン設定の削除ボタン押下イベント
+      console.log("onDeleteButtonSetting");
+      this.selectedPresetName = "";
+      this.setPresetNameList();
+    },
     setIsUseTestInputStream(isUseTestInputStream: boolean) {
       store.commit("setIsUseTestInputStream", isUseTestInputStream);
     },
@@ -229,6 +235,7 @@ export default defineComponent({
           :gamepadId="selectedGamepadId"
           :deviceId="selectedGamepadDevice"
           @onSaveButtonSetting="onSaveButtonSetting"
+          @onDeleteButtonSetting="onDeleteButtonSetting"
         />
       </div>
     </fieldset>

--- a/src/components/SiteSettings.vue
+++ b/src/components/SiteSettings.vue
@@ -50,7 +50,6 @@ export default defineComponent({
     },
     onDeleteButtonSetting() {
       // ボタン設定の削除ボタン押下イベント
-      console.log("onDeleteButtonSetting");
       this.selectedPresetName = "";
       this.setPresetNameList();
     },

--- a/src/components/SiteSettings.vue
+++ b/src/components/SiteSettings.vue
@@ -21,6 +21,8 @@ export default defineComponent({
       isUseTestInputStream: store.state.isUseTestInputStream,
       gamepads: [] as Gamepad[],
       devices: [] as Device[],
+      presetNames: [] as string[],
+
       selectedPresetName: "",
       selectedGamepadId: "",
       selectedGamepadDevice: "",
@@ -31,16 +33,20 @@ export default defineComponent({
       this.setBackGroundColor(this.backgroundColor);
     },
     onChangeGamepadSelection() {
-      console.log("onChangeGamepadSelection");
+      this.setPresetNameList();
     },
     onChangeDeviceSelection() {
-      console.log("onChangeDeviceSelection");
+      this.setPresetNameList();
     },
     onChangeServerUrl() {
       this.setServerUrl(this.serverUrl);
     },
     onChangeIsUseTestInputStream() {
       this.setIsUseTestInputStream(this.isUseTestInputStream);
+    },
+    onSaveButtonSetting() {
+      // ボタン設定の保存ボタン押下イベント
+      this.setPresetNameList();
     },
     setIsUseTestInputStream(isUseTestInputStream: boolean) {
       store.commit("setIsUseTestInputStream", isUseTestInputStream);
@@ -53,6 +59,17 @@ export default defineComponent({
       this.backgroundColor = color;
       store.commit("setBackgroundColor", color);
       this.$toast.success("背景色を変更しました。");
+    },
+    setPresetNameList() {
+      // 選択されたゲームパッドに対応するプリセット名を名称の昇順で取得
+      this.presetNames = store.state.buttonPictSettings
+        .filter(
+          (setting: any) =>
+            setting.gamepadId === this.selectedGamepadId &&
+            setting.device_id === this.selectedGamepadDevice
+        )
+        .map((setting: any) => setting.presetName)
+        .sort();
     },
     async updateGamepads() {
       try {
@@ -160,18 +177,6 @@ export default defineComponent({
       </legend>
 
       <div>
-        <p>
-          プリセット名を入力してください。同じパッドで複数のボタン表示を切り替えることができます。
-        </p>
-        <label for="listPresetName">プリセット名</label>
-        <input list="presetNameDataList" v-model="selectedPresetName" />
-        <datalist id="presetNameDataList">
-          <option value="Default"></option>
-          <option value="Custom"></option>
-        </datalist>
-
-        <hr />
-
         <p>ブラウザに接続されているゲームパッド</p>
         <select v-model="selectedGamepadId" @change="onChangeGamepadSelection">
           <option
@@ -202,11 +207,28 @@ export default defineComponent({
 
       <hr />
 
-      <div>
+      <p>
+        プリセット名を入力してください。同じプリセット名で保存した場合は上書きされます。
+      </p>
+      <label for="listPresetName">プリセット名</label>
+      <input list="presetNameDataList" v-model="selectedPresetName" />
+      <datalist id="presetNameDataList">
+        <option v-for="presetName in presetNames" :key="presetName">
+          {{ presetName }}
+        </option>
+      </datalist>
+
+      <hr />
+
+      <div v-if="selectedGamepadId === '' || selectedGamepadDevice === ''">
+        <p>【ゲームパッドを選択してください】</p>
+      </div>
+      <div v-else>
         <InputSettings
           :presetName="selectedPresetName"
           :gamepadId="selectedGamepadId"
           :deviceId="selectedGamepadDevice"
+          @onSaveButtonSetting="onSaveButtonSetting"
         />
       </div>
     </fieldset>

--- a/src/store.ts
+++ b/src/store.ts
@@ -31,7 +31,7 @@ const store = createStore({
             }
         },
         setButtonPictSetting(state: any, buttonPictSetting: ButtonPictSetting) {
-            const idx = state.buttonPictSettings.findIndex((bps: ButtonPictSetting) => bps.gamepadId === buttonPictSetting.gamepadId);
+            const idx = state.buttonPictSettings.findIndex((bps: ButtonPictSetting) => bps.presetName === buttonPictSetting.presetName && bps.gamepadId === buttonPictSetting.gamepadId && bps.device_id === buttonPictSetting.device_id);
             if (idx >= 0) {
                 state.buttonPictSettings[idx] = buttonPictSetting;
                 console.log("setButtonPictSetting", buttonPictSetting.gamepadId, "Updated.");

--- a/src/store.ts
+++ b/src/store.ts
@@ -40,6 +40,16 @@ const store = createStore({
                 console.log("setButtonPictSetting", buttonPictSetting.gamepadId, "Saved.");
             }
         },
+        deleteButtonPictSetting(state: any, payload: { presetName: string, gamepadId: string, device_id: string }) {
+            console.log("deleteButtonPictSetting", payload.presetName, payload.gamepadId, payload.device_id);
+            const idx = state.buttonPictSettings.findIndex((bps: ButtonPictSetting) => bps.presetName === payload.presetName && bps.gamepadId === payload.gamepadId && bps.device_id === payload.device_id);
+            if (idx >= 0) {
+                state.buttonPictSettings.splice(idx, 1);
+                console.log("deleteButtonPictSetting", payload.gamepadId, "Deleted.");
+            } else {
+                console.log("deleteButtonPictSetting", payload.gamepadId, "Not found.");
+            }
+        },
         setServerUrl(state: any, url: string) {
             state.serverUrl = url;
             if (process.env.NODE_ENV === "development") {

--- a/src/store.ts
+++ b/src/store.ts
@@ -54,13 +54,13 @@ const store = createStore({
         }
     },
     getters: {
-        getButtonPictSetting: (state) => (gamepadId: string, device_id: string) => {
-            const idx = state.buttonPictSettings.findIndex((bps: ButtonPictSetting) => bps.gamepadId === gamepadId && bps.device_id === device_id);
+        getButtonPictSetting: (state) => (presetName: string, gamepadId: string, device_id: string) => {
+            const idx = state.buttonPictSettings.findIndex((bps: ButtonPictSetting) => bps.presetName === presetName && bps.gamepadId === gamepadId && bps.device_id === device_id);
             console.log("getButtonPictSetting", gamepadId, device_id, idx);
             if (idx >= 0) {
                 return state.buttonPictSettings[idx];
             } else {
-                return new ButtonPictSetting(gamepadId, device_id);
+                return new ButtonPictSetting(presetName, gamepadId, device_id);
             }
         }
     }


### PR DESCRIPTION
プリセット名を入力してセーブ・ロードが出来るようになりました

close #4 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Translated the README to Japanese and shifted focus to user-oriented gamepad configuration guides.
  - Introduced preset management for gamepad settings, allowing users to select and manage presets easily.
  - Added functionality for saving and deleting button settings associated with presets.

- **Bug Fixes**
  - Enhanced logic for handling gamepad and preset selections to ensure accurate configuration.

- **Documentation**
  - Updated README to reflect changes and improve clarity for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->